### PR TITLE
Add time data to tap listings

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -63,6 +63,14 @@ html, body {
   margin: 0;
 }
 
+.last-updated {
+  color: #9f9f9f;
+}
+
+.empty .last-updated {
+  color: inherit;
+}
+
 .handle-container {
   width: 200px;
   position: relative;

--- a/dist/app.css
+++ b/dist/app.css
@@ -63,6 +63,14 @@ html, body {
   margin: 0;
 }
 
+.last-updated {
+  color: #9f9f9f;
+}
+
+.empty .last-updated {
+  color: inherit;
+}
+
 .handle-container {
   width: 200px;
   position: relative;

--- a/js/components/Tap.js
+++ b/js/components/Tap.js
@@ -3,8 +3,6 @@ import {connect} from 'react-redux';
 import classNames from 'classNames';
 import * as BeerActions from '../actions/BeerActions';
 import * as TapsActions from '../actions/TapsActions';
-import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
-import FlatButton from 'material-ui/FlatButton';
 import randomColor from 'randomColor';
 import BeerModal from './BeerModal';
 import ConfirmationDialog from './ConfirmationDialog';

--- a/js/components/Tap.js
+++ b/js/components/Tap.js
@@ -35,7 +35,7 @@ class Tap extends Component {
           {beer.breweries.length && <li>{_.first(beer.breweries).name}</li>}
           {beer.style && <li>{beer.style.shortName}</li>}
           {beer.abv && <li>{beer.abv}%</li>}
-          <li>{lastUpdated}</li>
+          <li className="last-updated">{lastUpdated}</li>
           <li><BeerModal data={beer} /></li>
         </ul>
       );
@@ -104,7 +104,7 @@ function humanTimeSince(timeStamp) {
   }
   if (secondsPast < 3600) {
     const minutes = parseInt(secondsPast / 60);
-    return  `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
+    return `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
   }
   if (secondsPast < 86400) {
     const hours = parseInt(secondsPast / 3600);

--- a/js/components/Tap.js
+++ b/js/components/Tap.js
@@ -28,12 +28,14 @@ class Tap extends Component {
 
   renderBeer() {
     let beer = this.props.beer;
+    const lastUpdated = this.props.data.updated ? humanTimeSince(this.props.data.updated) : "unknown";
     if (beer) {
       return (
         <ul className="beer-info">
           {beer.breweries.length && <li>{_.first(beer.breweries).name}</li>}
           {beer.style && <li>{beer.style.shortName}</li>}
           {beer.abv && <li>{beer.abv}%</li>}
+          <li>{lastUpdated}</li>
           <li><BeerModal data={beer} /></li>
         </ul>
       );
@@ -93,6 +95,28 @@ function mapDispatchToProps(dispatch) {
     fetchTaps: () => dispatch(TapsActions.fetchTaps()),
     setKicked: (building, room, handle, kicked) => dispatch(TapsActions.setKicked(building, room, handle, kicked))
   };
+}
+
+function humanTimeSince(timeStamp) {
+  const secondsPast = ((new Date()).getTime() - (new Date(timeStamp)).getTime()) / 1000;
+  if (secondsPast < 60) {
+    return "Just now!";
+  }
+  if (secondsPast < 3600) {
+    const minutes = parseInt(secondsPast / 60);
+    return  `${minutes} minute${minutes > 1 ? 's' : ''} ago`;
+  }
+  if (secondsPast < 86400) {
+    const hours = parseInt(secondsPast / 3600);
+    return `${hours} hour${hours > 1 ? 's' : ''} ago`;
+  }
+  if (secondsPast <= 2592000) {
+    const days = parseInt(secondsPast / 86400);
+    return `${days} day${days > 1 ? 's' : ''} ago`;
+  }
+  if (secondsPast > 2592000){
+    return timeStamp.toISOString().slice(0, 10);
+  }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Tap);

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-dom": "^15.3.0",
     "react-flexbox-grid": "^0.10.2",
     "react-redux": "^4.0.0",
-    "react-tap-event-plugin": "^1.0.0",
+    "react-tap-event-plugin": "^2.0.0",
     "redux": "^3.0.4",
     "redux-thunk": "^2.1.0",
     "semantic-react": "^0.8.2",

--- a/server/api.js
+++ b/server/api.js
@@ -61,7 +61,7 @@ module.exports.addEndpoints = function api(app) {
       handle: parseInt(req.params.handle)
     };
 
-    Tap.findOneAndUpdate({location}, {beer: req.body}, {runValidators: true}).exec().then(function (result, err) {
+    Tap.findOneAndUpdate({location}, {beer: req.body, updated: Date.now()}, {runValidators: true}).exec().then(function (result, err) {
       if (err) {
         console.error(err);
         res.status(500);
@@ -89,7 +89,7 @@ module.exports.addEndpoints = function api(app) {
       handle: parseInt(req.params.handle)
     };
 
-    Tap.findOneAndUpdate({location}, {kicked: req.body.kicked}, {runValidators: true}).exec().then(function (result, err) {
+    Tap.findOneAndUpdate({location}, {kicked: req.body.kicked, updated: Date.now()}, {runValidators: true}).exec().then(function (result, err) {
       if (err) {
         console.error(err);
         res.status(500);


### PR DESCRIPTION
I noticed that the app didn't show any sort of "last updated" information for the taps, which made it hard to tell if the current listings were accurate. Now the app stores an `updated` field for each tap (which I noticed was declared in `models.js` but was never used 🤷‍♂️)  and renders a human-friendly last-updated string under the beer's ABV. 

Since none of the beers have an `updated` field set, each of their last-updated strings will just be "unknown". I thought about just having it be an empty string instead, but I think this'll help motivate people to update the tap data.

Preview:
![Last updated field preview](http://i.imgur.com/cUyfeqj.png)